### PR TITLE
GH-55: Pack assemblies in corresponding TFM folder

### DIFF
--- a/src/Cake.BuildSystems.Module/Cake.BuildSystems.Module.csproj
+++ b/src/Cake.BuildSystems.Module/Cake.BuildSystems.Module.csproj
@@ -40,7 +40,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <None Include="$(OutputPath)/**/Cake.*" PackagePath="lib/" Pack="true" />
+      <None Include="$(OutputPath)/**/Cake.*" PackagePath="lib/$(TargetFramework)" Pack="true" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
It seems `dotnet pack` was doing some "magic" before and automatically appending the TFM folder name when we were targeting more than one TFM.

Once we moved from `TargetFrameworks` to `TargetFramework` it went through a different code path that doesn't include the "magic".

---

Closes #55