### PR TITLE
Add support for GitLab CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ Currently this module supports:
 
 - Log folding for the Cake build and for individual tasks
 
+### GitLab CI
+
+- Add colored output for Cake log messages in the GitLab pipeline output window
+
 ## Usage
 
 Each build system's functionality resides in its own module, with `Cake.Module.Shared` used for shared types. Each module will conditionally register itself, meaning they will only be loaded in their respective CI environments. This means all modules can be deployed with a single codebase without interference.
@@ -81,6 +85,7 @@ public static int Main(string[] args)
         .UseModule<MyGetModule>()
         .UseModule<TravisCIModule>()
         .UseModule<TeamCityModule>()
+        .UseModule<GitLabCIModule>()
         // continue with the "normal" setup of the CakeHost
         .UseContext<BuildContext>()
         .Run(args);

--- a/src/Cake.BuildSystems.Module.sln
+++ b/src/Cake.BuildSystems.Module.sln
@@ -25,6 +25,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cake.BuildSystems.Module", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cake.GitHubActions.Module", "Cake.GitHubActions.Module\Cake.GitHubActions.Module.csproj", "{A6BAA454-179C-422C-A954-38852265722F}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Cake.GitLabCI.Module", "Cake.GitLabCI.Module\Cake.GitLabCI.Module.csproj", "{DA6236E5-E4B3-42B4-BB3D-69CE06DAB85B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -115,6 +117,18 @@ Global
 		{A6BAA454-179C-422C-A954-38852265722F}.Release|x64.Build.0 = Release|Any CPU
 		{A6BAA454-179C-422C-A954-38852265722F}.Release|x86.ActiveCfg = Release|Any CPU
 		{A6BAA454-179C-422C-A954-38852265722F}.Release|x86.Build.0 = Release|Any CPU
+		{DA6236E5-E4B3-42B4-BB3D-69CE06DAB85B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DA6236E5-E4B3-42B4-BB3D-69CE06DAB85B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DA6236E5-E4B3-42B4-BB3D-69CE06DAB85B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DA6236E5-E4B3-42B4-BB3D-69CE06DAB85B}.Debug|x64.Build.0 = Debug|Any CPU
+		{DA6236E5-E4B3-42B4-BB3D-69CE06DAB85B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DA6236E5-E4B3-42B4-BB3D-69CE06DAB85B}.Debug|x86.Build.0 = Debug|Any CPU
+		{DA6236E5-E4B3-42B4-BB3D-69CE06DAB85B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DA6236E5-E4B3-42B4-BB3D-69CE06DAB85B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DA6236E5-E4B3-42B4-BB3D-69CE06DAB85B}.Release|x64.ActiveCfg = Release|Any CPU
+		{DA6236E5-E4B3-42B4-BB3D-69CE06DAB85B}.Release|x64.Build.0 = Release|Any CPU
+		{DA6236E5-E4B3-42B4-BB3D-69CE06DAB85B}.Release|x86.ActiveCfg = Release|Any CPU
+		{DA6236E5-E4B3-42B4-BB3D-69CE06DAB85B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Cake.BuildSystems.Module/Cake.BuildSystems.Module.csproj
+++ b/src/Cake.BuildSystems.Module/Cake.BuildSystems.Module.csproj
@@ -46,6 +46,9 @@
         <ProjectReference Include="..\Cake.GitHubActions.Module\Cake.GitHubActions.Module.csproj">
           <PrivateAssets>all</PrivateAssets>
         </ProjectReference>
+        <ProjectReference Include="..\Cake.GitLabCI.Module\Cake.GitLabCI.Module.csproj">
+          <PrivateAssets>all</PrivateAssets>
+        </ProjectReference>      
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Cake.GitLabCI.Module/AnsiEscapeCodes.cs
+++ b/src/Cake.GitLabCI.Module/AnsiEscapeCodes.cs
@@ -1,0 +1,15 @@
+namespace Cake.AzurePipelines.Module
+{
+    internal static class AnsiEscapeCodes
+    {
+        public static readonly string Reset = string.Format(FORMAT, 0);
+        public static readonly string ForegroundWhite = string.Format(FORMAT, 97);
+        public static readonly string ForegroundYellow = string.Format(FORMAT, 33);
+        public static readonly string ForegroundLightGray = string.Format(FORMAT, 37);
+        public static readonly string ForegroundDarkGray = string.Format(FORMAT, 90);
+        public static readonly string BackgroundMagenta = string.Format(FORMAT, 45);
+        public static readonly string BackgroundRed = string.Format(FORMAT, 41);
+
+        private const string FORMAT = "\u001B[{0}m";
+    }
+}

--- a/src/Cake.GitLabCI.Module/Cake.GitLabCI.Module.csproj
+++ b/src/Cake.GitLabCI.Module/Cake.GitLabCI.Module.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <AssemblyName>Cake.GitLabCI.Module</AssemblyName>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Cake.Module.Shared\Cake.Module.Shared.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Cake.Core" Version="4.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Common" Version="4.0.0" PrivateAssets="All" />
+    <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/src/Cake.GitLabCI.Module/GitLabCILog.cs
+++ b/src/Cake.GitLabCI.Module/GitLabCILog.cs
@@ -1,6 +1,8 @@
 using System;
+
 using Cake.Core;
 using Cake.Core.Diagnostics;
+
 using JetBrains.Annotations;
 
 namespace Cake.AzurePipelines.Module
@@ -14,8 +16,12 @@ namespace Cake.AzurePipelines.Module
         private static class AnsiEscapeCodes
         {
             public static readonly string Reset = string.Format(FORMAT, 0);
-            public static readonly string ForegroundRed = string.Format(FORMAT, 31);
+            public static readonly string ForegroundWhite = string.Format(FORMAT, 97);
             public static readonly string ForegroundYellow = string.Format(FORMAT, 33);
+            public static readonly string ForegroundLightGray = string.Format(FORMAT, 37);
+            public static readonly string ForegroundDarkGray = string.Format(FORMAT, 90);
+            public static readonly string BackgroundMagenta = string.Format(FORMAT, 45);
+            public static readonly string BackgroundRed = string.Format(FORMAT, 41);
 
             private const string FORMAT = "\u001B[{0}m";
         }
@@ -49,19 +55,27 @@ namespace Cake.AzurePipelines.Module
 
             // Use colored output for log messages on GitLab CI
             // For reference, see https://docs.gitlab.com/ee/ci/yaml/script.html#add-color-codes-to-script-output
+            // For the colors, mostly match the colors used by Cake, see https://github.com/cake-build/cake/blob/ed612029b92f5da2b6cbdfe295c62e6b99a2963d/src/Cake.Core/Diagnostics/Console/ConsolePalette.cs#L34C17-L34C17
+            // Not however, that the GitLab Web UI seems to render some colors the same (e.g. white and dark gray
             switch (level)
             {
                 case LogLevel.Fatal:
+                    _console.WriteErrorLine($"{AnsiEscapeCodes.BackgroundMagenta}{AnsiEscapeCodes.ForegroundWhite}{level}: {string.Format(format, args)}{AnsiEscapeCodes.Reset}");
+                    break;
                 case LogLevel.Error:
-                    _console.WriteLine($"{AnsiEscapeCodes.ForegroundRed}{level}: {string.Format(format, args)}{AnsiEscapeCodes.Reset}");
+                    _console.WriteErrorLine($"{AnsiEscapeCodes.BackgroundRed}{AnsiEscapeCodes.ForegroundWhite}{level}: {string.Format(format, args)}{AnsiEscapeCodes.Reset}");
                     break;
                 case LogLevel.Warning:
                     _console.WriteLine($"{AnsiEscapeCodes.ForegroundYellow}{level}: {string.Format(format, args)}{AnsiEscapeCodes.Reset}");
                     break;
                 case LogLevel.Information:
-                case LogLevel.Verbose:
-                case LogLevel.Debug:
                     _console.WriteLine($"{level}: {string.Format(format, args)}");
+                    break;
+                case LogLevel.Verbose:
+                    _console.WriteLine($"{AnsiEscapeCodes.ForegroundLightGray}{level}: {string.Format(format, args)}{AnsiEscapeCodes.Reset}");
+                    break;
+                case LogLevel.Debug:
+                    _console.WriteLine($"{AnsiEscapeCodes.ForegroundDarkGray}{level}: {string.Format(format, args)}{AnsiEscapeCodes.Reset}");
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(level), level, null);

--- a/src/Cake.GitLabCI.Module/GitLabCILog.cs
+++ b/src/Cake.GitLabCI.Module/GitLabCILog.cs
@@ -1,0 +1,78 @@
+using System;
+using Cake.Core;
+using Cake.Core.Diagnostics;
+using JetBrains.Annotations;
+
+namespace Cake.AzurePipelines.Module
+{
+    /// <summary>
+    /// <see cref="ICakeLog"/> implementation for GitLab CI.
+    /// </summary>
+    [UsedImplicitly]
+    public class GitLabCILog : ICakeLog
+    {
+        private static class AnsiEscapeCodes
+        {
+            public static readonly string Reset = string.Format(FORMAT, 0);
+            public static readonly string ForegroundRed = string.Format(FORMAT, 31);
+            public static readonly string ForegroundYellow = string.Format(FORMAT, 33);
+
+            private const string FORMAT = "\u001B[{0}m";
+        }
+
+        private readonly ICakeLog _cakeLogImplementation;
+        private readonly IConsole _console;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GitLabCILog"/> class.
+        /// </summary>
+        /// <param name="console">Implementation of <see cref="IConsole"/>.</param>
+        /// <param name="verbosity">Default <see cref="Verbosity"/>.</param>
+        public GitLabCILog(IConsole console, Verbosity verbosity = Verbosity.Normal)
+        {
+            _cakeLogImplementation = new CakeBuildLog(console, verbosity);
+            _console = console;
+        }
+
+        /// <inheritdoc />
+        public void Write(Verbosity verbosity, LogLevel level, string format, params object[] args)
+        {
+            if (!StringComparer.OrdinalIgnoreCase.Equals(Environment.GetEnvironmentVariable("CI_SERVER"), "yes"))
+            {
+                _cakeLogImplementation.Write(verbosity, level, format, args);
+            }
+
+            if (verbosity > Verbosity)
+            {
+                return;
+            }
+
+            // Use colored output for log messages on GitLab CI
+            // For reference, see https://docs.gitlab.com/ee/ci/yaml/script.html#add-color-codes-to-script-output
+            switch (level)
+            {
+                case LogLevel.Fatal:
+                case LogLevel.Error:
+                    _console.WriteLine($"{AnsiEscapeCodes.ForegroundRed}{level}: {string.Format(format, args)}{AnsiEscapeCodes.Reset}");
+                    break;
+                case LogLevel.Warning:
+                    _console.WriteLine($"{AnsiEscapeCodes.ForegroundYellow}{level}: {string.Format(format, args)}{AnsiEscapeCodes.Reset}");
+                    break;
+                case LogLevel.Information:
+                case LogLevel.Verbose:
+                case LogLevel.Debug:
+                    _console.WriteLine($"{level}: {string.Format(format, args)}");
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(level), level, null);
+            }
+        }
+
+        /// <inheritdoc />
+        public Verbosity Verbosity
+        {
+            get { return _cakeLogImplementation.Verbosity; }
+            set { _cakeLogImplementation.Verbosity = value; }
+        }
+    }
+}

--- a/src/Cake.GitLabCI.Module/GitLabCIModule.cs
+++ b/src/Cake.GitLabCI.Module/GitLabCIModule.cs
@@ -1,0 +1,25 @@
+using System;
+
+using Cake.Core.Annotations;
+using Cake.Core.Composition;
+using Cake.Core.Diagnostics;
+
+[assembly: CakeModule(typeof(Cake.AzurePipelines.Module.GitLabCIModule))]
+
+namespace Cake.AzurePipelines.Module
+{
+    /// <summary>
+    /// <see cref="ICakeModule"/> implementation for GitLab CI.
+    /// </summary>
+    public class GitLabCIModule : ICakeModule
+    {
+        /// <inheritdoc cref="ICakeModule.Register"/>
+        public void Register(ICakeContainerRegistrar registrar)
+        {
+            if (StringComparer.OrdinalIgnoreCase.Equals(Environment.GetEnvironmentVariable("CI_SERVER"), "yes"))
+            {
+                registrar.RegisterType<GitLabCILog>().As<ICakeLog>().Singleton();
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a module to support GitLab CI which provides a customized implementation of ICakeLog.
When the GitLabCI module is used, the log output will be shown colored in the GitLab Web UI.

I tired to match the colors to the ones used by Cake when running in an ANSI-enabled terminal.

I tested this with gitlab.com where the output from a build script will look like this when the module is active:
![image](https://github.com/cake-contrib/Cake.BuildSystems.Module/assets/2821818/a0d5ab10-a305-44c8-88b1-4cb67d87f026)

Further documentation on formatting output in GitLab CI can be found here <https://docs.gitlab.com/ee/ci/yaml/script.html#add-color-codes-to-script-output>