### PR TITLE
Fix namespace for types in Cake.GitLabCI.Module

### DIFF
--- a/src/Cake.GitLabCI.Module/AnsiEscapeCodes.cs
+++ b/src/Cake.GitLabCI.Module/AnsiEscapeCodes.cs
@@ -1,4 +1,4 @@
-namespace Cake.AzurePipelines.Module
+namespace Cake.GitLabCI.Module
 {
     internal static class AnsiEscapeCodes
     {

--- a/src/Cake.GitLabCI.Module/GitLabCILog.cs
+++ b/src/Cake.GitLabCI.Module/GitLabCILog.cs
@@ -6,7 +6,7 @@ using Cake.Core.Diagnostics;
 
 using JetBrains.Annotations;
 
-namespace Cake.AzurePipelines.Module
+namespace Cake.GitLabCI.Module
 {
     /// <summary>
     /// <see cref="ICakeLog"/> implementation for GitLab CI.

--- a/src/Cake.GitLabCI.Module/GitLabCIModule.Obsolete.cs
+++ b/src/Cake.GitLabCI.Module/GitLabCIModule.Obsolete.cs
@@ -1,0 +1,20 @@
+using System;
+
+using Cake.Core.Composition;
+
+namespace Cake.AzurePipelines.Module
+{
+    /// <summary>
+    /// Legacy <see cref="ICakeModule"/> implementation for GitLab CI.
+    /// </summary>
+    /// <remarks>
+    /// When <see cref="GitLabCIModule"/> was introduced initially, it was placed in the <c>Cake.AzurePipelines.Module</c> namespace by accident.
+    /// <para>
+    /// The namespace has since been adjusted, but this class is still provided in the <c>Cake.AzurePipelines.Module</c> namespace for backwards compatibility in Cake.Frosting projects.
+    /// When possible, use <see cref="GitLabCI.Module.GitLabCIModule"/> instead.
+    /// </para>
+    /// </remarks>
+    [Obsolete($"Use {nameof(GitLabCIModule)} from namespace Cake.GitLabCI.Module instead")]
+    public class GitLabCIModule : GitLabCI.Module.GitLabCIModule
+    { }
+}

--- a/src/Cake.GitLabCI.Module/GitLabCIModule.cs
+++ b/src/Cake.GitLabCI.Module/GitLabCIModule.cs
@@ -4,9 +4,9 @@ using Cake.Core.Annotations;
 using Cake.Core.Composition;
 using Cake.Core.Diagnostics;
 
-[assembly: CakeModule(typeof(Cake.AzurePipelines.Module.GitLabCIModule))]
+[assembly: CakeModule(typeof(Cake.GitLabCI.Module.GitLabCIModule))]
 
-namespace Cake.AzurePipelines.Module
+namespace Cake.GitLabCI.Module
 {
     /// <summary>
     /// <see cref="ICakeModule"/> implementation for GitLab CI.


### PR DESCRIPTION
When the GitLab CI module was introduced initially (see !165), the types were placed in the 'Cake.AzurePipelines.Module' namespace by accident.
To fix this and make the namespaces consistent with the package and assembly structure, move all types to the 'Cake.GitLabCI.Module' namespace.

While this is a breaking change, the impact is mitigated in two ways:

- Builds using the Cake scripting runner automatically discover modules by looking for the 'CakeModule' attribute. The change should thus be transparent to these projects
- For Cake.Frosting based builds, a second "GitLabCIModule" type is kept in the Cake.AzurePipelines.Module namespace so the module should be source-compatible with earlier versions

The GitLabCIModule in Cake.AzurePipelines.Module was marked as obsolete to discourage usage.
